### PR TITLE
allow to access included in relation sideload

### DIFF
--- a/lib/sinja.rb
+++ b/lib/sinja.rb
@@ -157,6 +157,15 @@ module Sinja
         end
       end
 
+      def included
+        @included ||= {}
+        @included[request.path] ||= begin
+          deserialize_request_body.fetch(:included, nil)
+        rescue NoMethodError, KeyError
+          raise BadRequestError, 'Malformed {json:api} request payload'
+        end
+      end
+
       def normalize_filter_params
         return {} unless params[:filter]&.any?
 

--- a/lib/sinja/helpers/relationships.rb
+++ b/lib/sinja/helpers/relationships.rb
@@ -23,6 +23,7 @@ module Sinja
         rels = data.fetch(:relationships, {}).to_a
         rels.each do |rel, body, rel_type=nil, count=0|
           rel_type ||= settings._resource_config[:has_one].key?(rel) ? :has_one : :has_many
+          body = body.merge(included: included) if included
           code, _, *json = dispatch_relationship_request id, rel,
             opts.merge(:body=>body, :method=>methods.fetch(rel_type, :patch))
 


### PR DESCRIPTION
Hey, 

I need a feature of jsonapi1.1 that is still wip. It is about sideposting models (https://github.com/json-api/json-api/pull/1197) 

With my additions to sinja I donot break the 1.0 spec. But allows the user to access the Included Elements on post and allows the user to handle the sideposting by him self. 

@mwpastore what's your opinion about that? 